### PR TITLE
Updated setActiveWallet.ts for fetching test wallet address

### DIFF
--- a/.changeset/hot-experts-smoke.md
+++ b/.changeset/hot-experts-smoke.md
@@ -1,0 +1,5 @@
+---
+"chukti": minor
+---
+
+feat: new feature added for fetching test wallet address

--- a/docs/step-definitions/blockchain.md
+++ b/docs/step-definitions/blockchain.md
@@ -24,6 +24,11 @@ When I set the active test wallet address to the index {index}
 ```
 [Read details](#switch-wallet-2)
 
+```gherkin
+When I fetch the wallet address at index {index}
+```
+[Read details](#fetch-wallet-index)
+
 ## Detailed Step Definitions
 
 ### :rocket: Then I validate the status of the last transaction is "expectedStatus" {#validate-transaction-status}
@@ -65,6 +70,19 @@ To set the active test wallet address to the specified index in the test client 
 ::: details **Example:**
 ```gherkin
 Given I set the active test wallet address to the index 1
+```
+:::
+
+### :rocket: When I fetch the wallet address at index {index} {#fetch-wallet-index}
+- **Purpose**
+To fetch the wallet address from the provided index without setting it as the active wallet.
+
+- **Required Values:**
+    - `index`: The index of the wallet address in the test client list.
+
+::: details **Example**
+```gherkin
+When I fetch the wallet address at index 2
 ```
 :::
 

--- a/src/cucumber/register.ts
+++ b/src/cucumber/register.ts
@@ -24,6 +24,7 @@ import { verifyContractPathStep } from "./steps/contract/verifyPath.js";
 import { writeContractStep } from "./steps/contract/write.js";
 import { resultComparisonStep } from "./steps/generic/dataComparison.js";
 import { storeResultStep } from "./steps/generic/storeResult.js";
+import { fetchWalletByIndexStep } from "./steps/blockchain/setActiveWallet.js";
 
 /**
  * Parameters required for registering Chukti steps with the Cucumber framework.
@@ -94,6 +95,11 @@ export const registerChuktiSteps = ({
   Then(
     "I validate the status of the last transaction is {string}",
     validateTxnStep,
+  );
+
+  When(
+    "I fetch the wallet address at index {int}",
+    fetchWalletByIndexStep
   );
   When(
     "I set the active test wallet address to the address {string}",

--- a/src/cucumber/steps/blockchain/setActiveWallet.ts
+++ b/src/cucumber/steps/blockchain/setActiveWallet.ts
@@ -38,3 +38,19 @@ export const setActiveWalletByIndexStep = async (index: number) => {
     `Active test wallet address set to address at index ${index}: ${testWallet}`,
   );
 };
+
+/**
+ * Fetches the wallet address by the provided index
+ * @param index- The index of the test wallet address to set as active.
+ * 
+ * @example
+ * import { fetchWalletByIndexStep } from "chukti";
+ * When("I fetch the wallet address at index {int}", fetchWalletByIndexStep);
+ */
+
+export const fetchWalletByIndexStep = async (index: number) => {
+  const testWallet = await getTestWalletAddress({ index });
+
+  // Log the fetched wallet without setting it as active
+  world.log(`Fetched wallet address at index ${index}: ${testWallet}`);
+};

--- a/src/cucumber/steps/blockchain/setActiveWallet.ts
+++ b/src/cucumber/steps/blockchain/setActiveWallet.ts
@@ -50,6 +50,10 @@ export const setActiveWalletByIndexStep = async (index: number) => {
 
 export const fetchWalletByIndexStep = async (index: number) => {
   const testWallet = await getTestWalletAddress({ index });
+  if(!world.chukti){
+    world.chukti ={};
+  }
+  world.chukti.lastResult = testWallet;
 
   // Log the fetched wallet without setting it as active
   world.log(`Fetched wallet address at index ${index}: ${testWallet}`);


### PR DESCRIPTION
Related Issue:  #29
This pull request introduces new step definitions to enhance our testing framework by **allowing the retrieval of wallet addresses based on their index from a local blockchain** . This functionality is essential for improving our interaction with test wallets, making it easier to manage and validate wallet addresses during testing.

Changes Made:
1. Added the `fetchWalletByIndexStep` function to `setActiveWallet.js`, which allows users to fetch and log the wallet address corresponding to a specified index without setting it as the active wallet.
2. This new step is registered in register.ts to enable its usage in Cucumber tests.

Example usage
```javascript
When("I fetch the wallet address at index {int}", fetchWalletByIndexStep);
```